### PR TITLE
Update gstwebrtcice.c

### DIFF
--- a/ext/webrtc/gstwebrtcice.c
+++ b/ext/webrtc/gstwebrtcice.c
@@ -108,7 +108,7 @@ _gst_nice_thread (GstWebRTCICE * ice)
 
   g_mutex_lock (&ice->priv->lock);
   g_main_context_unref (ice->priv->main_context);
-  ice->priv->main_context = NULL; 
+  ice->priv->main_context = NULL;
   g_main_loop_unref (ice->priv->loop);
   ice->priv->loop = NULL;
   g_cond_broadcast (&ice->priv->cond);

--- a/ext/webrtc/gstwebrtcice.c
+++ b/ext/webrtc/gstwebrtcice.c
@@ -108,7 +108,7 @@ _gst_nice_thread (GstWebRTCICE * ice)
 
   g_mutex_lock (&ice->priv->lock);
   g_main_context_unref (ice->priv->main_context);
-  ice->priv->main_context = NULL;
+  ice->priv->main_context = NULL; 
   g_main_loop_unref (ice->priv->loop);
   ice->priv->loop = NULL;
   g_cond_broadcast (&ice->priv->cond);
@@ -287,7 +287,7 @@ _parse_userinfo (const gchar * userinfo, gchar ** user, gchar ** pass)
     return;
   }
 
-  colon = g_strstr_len (userinfo, -1, ":");
+  colon = g_strrstr_len (userinfo, -1, ":");
   if (!colon) {
     *user = g_strdup (userinfo);
     *pass = NULL;


### PR DESCRIPTION
This patch fixes an issue with valid TURN credentials following the COTORN rules of creating a "usercombo" for OTPs:

(from /etc/turnserver.conf)

```
# This option is used with timestamp:
# 
# usercombo -> "timestamp:userid"
# turn user -> usercombo
# turn password -> base64(hmac(secret key, usercombo))

```
The current solution does not parse the username correctly, if it contains a ":", since the code is treating the first appearance as delimiter between username and password. Hence all authentication attempts at COTURN will fail, since Gst is using the wrong username.

The fix - initially provided by @selamipak and published here https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues/831 - has been validated to work and is applied as PR by me now.

Feel free to use it.